### PR TITLE
Adjust stepping and CPU map to eschew rewiring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ this is my fork of usbcnc for STM32F103 specially for board in my chinnese machi
 
 ![Board](https://github.com/mirecta/grbl/blob/edge/doc/media/usbmach_pins.jpg?raw=true)
 
-U must remove three capacitors and solder 3 wires, because this would recquire masive sw patches , so better is patch with three wires
+NOTE: On my usbmach v2.0 the SWD pin order, left to right as pictured below, is actually VCC,GND,SWDIO,SWCLK Once I figured that out (with the STM32 chip pinout and a multimeter) it programmed just fine with an ST-LINK V2 and STM32CubeProgrammer 
+
+Ignore the wire patch lines, that is no longer necessary.
 
 ![patch](https://github.com/mirecta/grbl/blob/edge/doc/media/usbmach_patch.jpg?raw=true)
 

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -285,20 +285,30 @@
 
 #ifdef CPU_MAP_STM32F103
 
-  // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
+  // Define step pulse output pins. NOTE: All step bit pins must be on the same port...  Or must they?
+  // Attempt to split potential pins onto two ports without mucking about with the rest of the code for STM32...  
+  // This could be tricky...
+#define H_PORT_OFFSET   16
+#define L_PORT_MASK     0xFFFF  //Sorry, too tired to bother with deriving one from the other.  You get what you pay for.
 #define STEP_PORT       GPIOB
 #define RCC_STEP_PORT   RCC_APB2Periph_GPIOB
-#define X_STEP_BIT      7
-#define Y_STEP_BIT      5
+#define H_STEP_PORT     GPIOA                //We're going to stack the pins on the A controller to the 
+#define H_RCC_STEP_PORT RCC_APB2Periph_GPIOA //left of the pins on the B controller
+#define X_STEP_BIT      ( 5 + H_PORT_OFFSET )
+#define Y_STEP_BIT      ( 7 + H_PORT_OFFSET )
 #define Z_STEP_BIT      1
 #define A_STEP_BIT      11
 #define B_STEP_BIT      14
 #define STEP_MASK       ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)|(1<<A_STEP_BIT)|(1<<B_STEP_BIT)) // All step bits
 
-  // Define step direction output pins. NOTE: All direction pins must be on the same port.
-#define DIRECTION_PORT      GPIOB
+  // Define direction pulse output pins. NOTE: All direction bit pins must be on the same port...  Or must they?
+  // Attempt to split potential pins onto two ports without mucking about with the rest of the code for STM32...  
+  // This could be tricky...
+#define DIRECTION_PORT       GPIOB
 #define RCC_DIRECTION_PORT   RCC_APB2Periph_GPIOB
-#define X_DIRECTION_BIT   6
+#define H_DIRECTION_PORT     GPIOA
+#define H_RCC_DIRECTION_PORT RCC_APB2Periph_GPIOA
+#define X_DIRECTION_BIT   ( 6 + H_PORT_OFFSET )
 #define Y_DIRECTION_BIT   0
 #define Z_DIRECTION_BIT   10
 #define A_DIRECTION_BIT   12

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -76,7 +76,7 @@ void _delay_ms(uint32_t x);
 void _delay_us(uint32_t x);
 #define false 0
 #define true 1
-#define PORTPINDEF uint16_t
+#define PORTPINDEF uint32_t
 typedef int bool;
 //#define NOEEPROMSUPPORT
 #define printPgmString printString

--- a/grbl/planner.h
+++ b/grbl/planner.h
@@ -62,7 +62,7 @@ typedef struct {
   uint32_t step_event_count; // The maximum step axis count and number of steps required to complete this block.
 
   #ifdef STM32F103C8
-    uint16_t direction_bits;    // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
+    uint32_t direction_bits;    // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
   #else
     uint8_t direction_bits;    // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
   #endif


### PR DESCRIPTION
Very simple really, GRBL does its step timing calculations and scheduling on one set of bitmasks,
therefore in the original setup, all GPIO pins for each operation must be on the same port.

However, it is simple enough to create the bitmask as 32-bits wide, let GRBL do all its math,
and then split it in half and write it to two separate ports as necessary.

I may expand this approach to additional functions as I continue to suss out which pins are attached to what.